### PR TITLE
Remove explicit usage of GCC11 as GCC11 will now be default compiler

### DIFF
--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -32,21 +32,6 @@ pushd cmake/external/json
 ln -s $BUILD_PREFIX/include single_include
 popd
 
-PATH_VAR="$PATH"
-if [[ $ppc_arch == "p10" ]]
-then
-    if [[ -z "${GCC_11_HOME}" ]];
-    then
-        echo "Please set GCC_11_HOME to the install path of gcc-toolset-11"
-        exit 1
-    else
-        export PATH=${GCC_11_HOME}/bin/:$PATH
-    fi
-    GCC_USED=`which gcc`
-    echo "GCC being used is ${GCC_USED}"
-fi
-
-
 # Needs eigen 3.4
 # rm -rf cmake/external/eigen
 # pushd cmake/external

--- a/recipe/build.sh
+++ b/recipe/build.sh
@@ -73,7 +73,7 @@ then
     export CXXFLAGS="${CXXFLAGS} -mtune=power10"
     export CFLAGS="${CFLAGS} -mtune=power10"
     # Removing these libs so that libonnxruntime.so links against libstdc++.so present on
-    # the system provided by gcc-toolset-10
+    # the system provided by gcc-toolset-11
     rm ${PREFIX}/lib/libstdc++.so*
     rm ${BUILD_PREFIX}/lib/libstdc++.so*
     LTO=""

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -29,12 +29,11 @@ source:
     folder: cpuinfo
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: h{{ PKG_HASH }}_{{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
   script_env:
     - CUDA_HOME      #[build_type == 'cuda']
-    - GCC_11_HOME    # [ppc_arch == "p10"]
 
 requirements:
   build:


### PR DESCRIPTION
## Checklist before submitting

- [ ] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Earlier we had explicitly made the recipe to use GCC11 as GCC 10 was default compiler for P10 builds. But now since we are changing default compiler to GCC 11, this extra code isn't needed anymore.

## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
