### PR TITLE
Fix build failure on P9

### DIFF
--- a/recipe/0001-Eigen-patch-to-disable-MMA.patch
+++ b/recipe/0001-Eigen-patch-to-disable-MMA.patch
@@ -1,0 +1,44 @@
+From 3c59500db10994116df5bf53d4dcc6e7ccb9989f Mon Sep 17 00:00:00 2001
+From: Deepali Chourasia <deepch23@in.ibm.com>
+Date: Mon, 4 Mar 2024 15:08:30 +0000
+Subject: [PATCH] Eigen patch to disable MMA
+
+update
+---
+ cmake/external/eigen.cmake                            |  1 +
+ ...01-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch | 11 +++++++++++
+ 2 files changed, 12 insertions(+)
+ create mode 100644 cmake/patches/eigen/0001-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch
+
+diff --git a/cmake/external/eigen.cmake b/cmake/external/eigen.cmake
+index c0f7ddc50e..2f798531f0 100644
+--- a/cmake/external/eigen.cmake
++++ b/cmake/external/eigen.cmake
+@@ -16,6 +16,7 @@ else ()
+             eigen
+             URL ${DEP_URL_eigen}
+             URL_HASH SHA1=${DEP_SHA1_eigen}
++            PATCH_COMMAND ${Patch_EXECUTABLE} -p1 --ignore-whitespace < ${PROJECT_SOURCE_DIR}/patches/eigen/0001-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch
+         )
+     endif()
+     FetchContent_Populate(eigen)
+diff --git a/cmake/patches/eigen/0001-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch b/cmake/patches/eigen/0001-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch
+new file mode 100644
+index 0000000000..454ec19572
+--- /dev/null
++++ b/cmake/patches/eigen/0001-patch-to-define-EIGEN_ALTIVEC_DISABLE_MMA.patch
+@@ -0,0 +1,11 @@
++--- ./Eigen/src/Core/arch/AltiVec/MatrixProduct.h	2024-03-04 14:58:57.571332979 +0000
+++++ ./Eigen/src/Core/arch/AltiVec/MatrixProduct.h	2024-03-04 14:59:11.640797615 +0000
++@@ -28,6 +28,8 @@
++ #endif
++ #endif
++ 
+++#define EIGEN_ALTIVEC_DISABLE_MMA
+++
++ #ifdef __has_builtin
++ #if __has_builtin(__builtin_mma_assemble_acc)
++   #define ALTIVEC_MMA_SUPPORT
+-- 
+2.40.1
+

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -16,9 +16,10 @@ source:
       - 0001-Fix-shared-lib-re2-not-found.patch
       - 0001-Fixed-onnxruntime-for-flatbuffers.patch
       - 0001-Pin-numpy-to-open-ce-s-version.patch
+      - 0001-Eigen-patch-to-disable-MMA.patch                        #[ppc_arch != "p10"]
 
 build:
-  number: 1
+  number: 2
   string: h{{ PKG_HASH }}_{{ build_type }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }}   #[build_type == 'cpu']
   string: h{{ PKG_HASH }}_{{ build_type }}{{ cudatoolkit | replace(".*", "") }}_py{{ python | replace(".", "") }}_pb{{ protobuf | replace(".*", "")}}_{{ PKG_BUILDNUM }} #[build_type == 'cuda']
   script_env:


### PR DESCRIPTION
## Checklist before submitting

- [x] Did you read the [contributor guide](https://github.com/open-ce/open-ce/blob/main/CONTRIBUTING.md)?
- [ ] Did you update any affected [documentation](https://github.com/open-ce/open-ce/blob/main/doc/)?
- [ ] Did you write any tests to validate this change?

## Description

Fix the following errors by disabling MMA directive in `eigen-src/Eigen/src/Core/arch/AltiVec/MatrixProduct.h` using a patch (ref - https://bugzilla.redhat.com/show_bug.cgi?id=1996330#c1) :
```
lto1: error: '__builtin_mma_disassemble_acc_internal' requires the '-mmma' option
lto1: fatal error: target specific builtin not available
lto-wrapper: fatal error: $BUILD_PREFIX/bin/powerpc64le-conda-linux-gnu-c++ returned 1 exit status
$BUILD_PREFIX/bin/../lib/gcc/powerpc64le-conda-linux-gnu/11.2.0/../../../../powerpc64le-conda-linux-gnu/bin/ld: error: lto-wrapper failed
collect2: error: ld returned 1 exit status
```

```
$SRC_DIR/build-ci/Release/_deps/eigen-src/Eigen/src/Core/arch/AltiVec/MatrixProduct.h:2484:73: error: builtin '__builtin_cpu_supports' needs GLIBC (2.23 and newer) that exports hardware capability bits [-Werror]
 2484 |       if (__builtin_cpu_supports ("arch_3_1") && __builtin_cpu_supports ("mma")){
      |                                                  ~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~

```


## Review process to land 

1. All tests and other checks must succeed.
2. At least one [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) must review and approve.
3. If any  [maintainer](https://github.com/open-ce/open-ce/blob/main/MAINTAINERS.md) requests changes, they must be addressed.
